### PR TITLE
Packages can now read Packages.gz from a list of repos provided in tmms

### DIFF
--- a/blueprints/10-l4tm_packages/blueprint.py
+++ b/blueprints/10-l4tm_packages/blueprint.py
@@ -165,8 +165,8 @@ def get_all_mirrors():
     areas = list(BP.config['DEBIAN_AREAS'])
     areas = ' '.join(areas)
 
-    main_source = 'deb {url} {release} {areas}'\
-                    .format(url=mirror, release=release, areas=areas)
+    main_source = 'deb {url} {release} {areas}'.format(
+                                    url=mirror,release=release, areas=areas)
 
     all_mirrors = BP.config['OTHER_MIRRORS']
     #unlikly, but someone might use set instead of list. Thus - make it a list.

--- a/blueprints/99-manifests/blueprint.py
+++ b/blueprints/99-manifests/blueprint.py
@@ -278,7 +278,7 @@ class ManifestDestiny(object):
         man = self.thedict
         nosuch = BP.mainapp.blueprints['package'].filter(man['packages'])
         #FIXME: Validate PACKAGE exist in mirror!
-        #assert not nosuch, 'no such package(s): ' + ', '.join(nosuch)
+        assert not nosuch, 'no such package(s): ' + ', '.join(nosuch)
 
         nosuch = BP.mainapp.blueprints['task'].filter(man['tasks'])
         assert not nosuch, 'no such task(s): ' + ', '.join(nosuch)

--- a/tests/test_packages/test_packages.py
+++ b/tests/test_packages/test_packages.py
@@ -39,6 +39,15 @@ class PackageTest(unittest.TestCase):
                         response.status_code)
 
 
+    def test_manifesting_inList(self):
+        """ Need to test OTHER_MIRRORS capailities. tm-manifesting should typically
+        come from OTHER_MIRRORS, so check if it is in the list of all packages.
+        NOTE: This might not be true at some point.
+        """
+        response = self.client.get(self.base_endpoint + 'package/tm-manifesting')
+        self.assertTrue(response.status_code == 200)
+
+
     def test_pkg_not_exists(self):
         """ Test if showpkg will return error message for non-existed package. """
         response = self.client.get(self.base_endpoint + 'package/PlanetExpress')

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -51,6 +51,36 @@ class UtilsTest(unittest.TestCase):
         self.assertTrue(os.path.exists(uncompressed_dir + '/' + test_file_name))
 
 
+    def test_deb_components_valid(self):
+        '''
+            Validate sources.list url can be parsed properly by checking
+            url, release and areas values match between origin and parsed.
+        '''
+        url = 'http://some.deb.mirror/debian/'
+        release = 'jessie'
+        areas = 'main contrib'
+        full_source = 'deb {url} {release} {areas}'\
+                    .format(url=url, release=release, areas=areas)
+        pieces = TmmsUtils.deb_components(full_source)
+
+        self.assertTrue(url == pieces.url)
+        self.assertTrue(release == pieces.release)
+        self.assertTrue(areas.split(' ') == pieces.areas)
+
+
+    def test_deb_components_invalid(self):
+        ''' '''
+        url = 'http://some.deb.mirror/debian/'
+        release = 'jessie'
+        areas = 'main contrib'
+        full_source = '{url} {release} {areas}'\
+                    .format(url=url, release=release, areas=areas)
+        pieces = TmmsUtils.deb_components(full_source)
+
+        self.assertFalse(pieces.url)
+        self.assertFalse(pieces.release)
+        self.assertFalse(pieces.areas)
+
 
     def touch_file(self, filename):
         """ Touch a file that will be used for testing. """


### PR DESCRIPTION
- this enables proper package list in the manifest verification
- tested with unittests as well as manual node build process successfully 