### PR TITLE
Find errors in log

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,6 @@ import sys
 
 from pdb import set_trace
 
-#from tmms.utils import utils
-
 
 def link_into_python(args, git_repo_path):
     """

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from shutil import rmtree
 
-from tmms.utils.logging import tmmsLogger
+from tmms.utils import logging
 from pdb import set_trace
 
 
@@ -23,8 +23,8 @@ class UtilsLoggerTest(unittest.TestCase):
     def setUp(cls):
         if os.path.exists(cls.logfile):     # From previous run
             os.remove(cls.logfile)
-        tmmsLogger.reconfigure_rootlogger(use_file=cls.logfile)
-        cls.logger = tmmsLogger(cls.app_name)
+        logging.tmmsLogger.reconfigure_rootlogger(use_file=cls.logfile)
+        cls.logger = logging.tmmsLogger(cls.app_name)
 
     '''
     @classmethod
@@ -62,7 +62,7 @@ class UtilsLoggerTest(unittest.TestCase):
         debug_logfile = '/tmp/unittest_logging.debug'
         if os.path.isfile(debug_logfile):
             os.remove(debug_logfile)
-        self.logger = tmmsLogger(
+        self.logger = logging.tmmsLogger(
             'test_debug_log', use_file=debug_logfile, verbose=True)
         self.logger(msg, 'DEBUG')
 
@@ -151,6 +151,15 @@ class UtilsLoggerTest(unittest.TestCase):
         except RuntimeError as e:
             threwRuntimeError = True
         self.assertTrue(threwRuntimeError, 'No RuntimeError after shutdown()')
+
+
+    def test_get_log_error(self):
+        mock_log = os.path.realpath(__file__)
+        mock_log = os.path.dirname(mock_log) + '/mock/build.log'
+
+        log_errors = logging.get_log_errors(mock_log)
+        self.assertTrue(len(log_errors) > 0)
+
 
     def isEntryInLog(self, entry, level=None, logfile=None):
         log_entries = None

--- a/utils/customize_node.py
+++ b/utils/customize_node.py
@@ -88,10 +88,9 @@ def extract_bootfiles(args, keep_kernel=False):
     for source in vmlinuz + initrd + misc:            # move them all
         dest = '%s/%s' % (args.build_dir, os.path.basename(source))
         if keep_kernel:
-            msg = 'Copy of %s failed' % source
-            assert file_utils.copy_target_into(source, dest), msg
+            file_utils.copy_target_into(source, dest)
         else:
-            assert file_utils.move_target(source, dest), 'Move of %s failed' % source
+            file_utils.move_target(source, dest)
 
         if '/vmlinuz' in dest:
             args.vmlinuz_golden = dest

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -138,3 +138,48 @@ class tmmsLogger(object):   # FIXME: how about subclassing getLogger?
         if attr in self._okattr:
             return getattr(self._logger, attr)
         raise AttributeError(attr)
+
+
+# ---------------------------------------------------------------------------- #
+
+
+def get_log_errors(log_file):
+    """
+        Parse .log file created my tmmsLogger to find and lines with ERROR entries.
+
+    param @log_files: <str> path to a log file to parse.
+    return: list of lines of ERROR entries.
+    """
+    if not os.path.exists(log_file):
+        return []
+
+    output = [] # lines with ERROR message
+    log_content = None
+    with open(log_file, 'r') as file_obj:
+        log_content = file_obj.read()
+
+    log_lines = log_content.split('\n')
+    for line_number in range(len(log_lines)):
+        line = log_lines[line_number]
+        if 'ERROR' in line:
+            next_few_lines = log_lines[line_number+1:line_number+6]
+            error_dsc = _get_description_lines(next_few_lines)
+            full_error = [line]
+            full_error.extend(error_dsc)
+            output.append('\n'.join(full_error))
+
+    return output
+
+
+def _get_description_lines(lines):
+    """
+        This function used by get_log_errors() to extract few lines of description
+    for an ERROR entry that was found.
+    """
+    result = []
+    for line in lines:
+        if 'ERROR' in line or 'WARNING' in line or 'INFO' in line:
+            break
+        result.append(line)
+
+    return result


### PR DESCRIPTION
This helps to find ERROR state logged by python's "logger". When building under chroot, for example, the ERROR state is not captured by caller script (setup_golden.py or even by blueprint scripts). This changes help to read any log file, find ERRORS and exit with the error message.

Catching chrooted errors (under untar/root/install.log) is not implemented yet, but mechanism is in place to do so.